### PR TITLE
bit reset size_t caused to form infinite loop

### DIFF
--- a/bitset_header/bitset.hpp
+++ b/bitset_header/bitset.hpp
@@ -27,8 +27,12 @@ public:
 	
 	friend std::ostream& operator<<(std::ostream& out, const bitset& b)
 	{
-		for(std::size_t x{b.m_bitlength-1}; x>=0; --x)
+		for(std::size_t x{b.m_bitlength-1};; --x)
+		{
 			out << (b.ison(x))?"1":"0";
+			if(x==0)
+				break;
+		}
 			
 		return out;
 	}


### PR DESCRIPTION
size_t is uint so when in for loop as per last one x<=0 and when it goes beyond 0 it resets to max causing infinite loop